### PR TITLE
Fix: syntax error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ README
 
 Description:
 
-unixODBC-MSSQL is a refined fork of [unixODBC]. (http://www.unixodbc.org/)
+unixODBC-MSSQL is a refined fork of [unixODBC](http://www.unixodbc.org/).
 	unixODBC is an Open Source ODBC sub-system and an ODBC SDK
 	for Linux, Mac OSX, and UNIX. 
 	


### PR DESCRIPTION
I believed we do want create a link with text `unixODBC` here, or we would not put a `[]` on it.